### PR TITLE
OP-436: Allow TotalAmount to have value 'M' for only one contribution

### DIFF
--- a/app/src/main/assets/pages/Premium.js
+++ b/app/src/main/assets/pages/Premium.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
     document.title = Android.getString('AddEditPremium');
 
     var adj = Android.getSpecificControlHtml("TotalAmount");
-    if (adj == "R") {
+    if (adj == "M" || adj == "R") {
         $('#txtAmount').attr('readonly', 'readonly');
     }
 

--- a/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
+++ b/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
@@ -309,9 +309,8 @@ public class NotEnrolledPoliciesOverview extends AppCompatActivity {
         addListenerOnSpinnerItemSelection(paymentType);
 
         finalAmount.setText(Number);
-        if (clientAndroidInterface.getSpecificControl("TotalAmount").equals("R")) {
-            finalAmount.setEnabled(false);
-        }
+        String totalAmountControl = clientAndroidInterface.getSpecificControl("TotalAmount");
+        finalAmount.setEnabled(!"M".equals(totalAmountControl) && !"R".equals(totalAmountControl));
 
         // set dialog message
         alertDialogBuilder

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -301,10 +301,8 @@ public class OverViewPolicies extends AppCompatActivity {
         addItemsOnSpinner2(payment_type);
         addListenerOnSpinnerItemSelection(payment_type);
 
-        amount.setText(Number);
-        if (clientAndroidInterface.getSpecificControl("TotalAmount").equals("R")) {
-            amount.setEnabled(false);
-        }
+        String totalAmountControl = clientAndroidInterface.getSpecificControl("TotalAmount");
+        amount.setEnabled(!"M".equals(totalAmountControl) && !"R".equals(totalAmountControl));
 
         // set dialog message
         alertDialogBuilder


### PR DESCRIPTION
Changes:
- Fixed `TotalAmount` control field checks to accept both `M` and `R`  values as "mandatory"

[https://openimis.atlassian.net/browse/OTC-438](https://openimis.atlassian.net/browse/OTC-438)