### PR TITLE
OP-440: Add loading product flavours from another file in mobile apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ fastlane/readme.md
 
 app/release/output.json
 **/.DS_Store
+
+# Custom product flavours
+
+*custom-flavours.gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,11 @@ apply plugin: 'com.android.application'
 apply from: "$project.rootDir/script-git-version.gradle"
 apply plugin: 'com.android.application'
 
+// Apply custom flavours
+if(file('custom-flavours.gradle').exists()){
+    apply from: 'custom-flavours.gradle'
+}
+
 // Load keystore
 def keystorePropertiesFile = file("keystore.properties");
 def keystoreProperties = new Properties()

--- a/app/custom-flavours.gradle.dist
+++ b/app/custom-flavours.gradle.dist
@@ -1,0 +1,19 @@
+// Please refer to build.gradle file for examples how to define a custom product flavour
+android {
+    productFlavors {
+        example {
+            applicationId [APPLICATION_ID]
+            buildConfigField "String", "API_BASE_URL", [API_BASE_URL]
+            buildConfigField "boolean", "SHOW_PAYMENT_MENU", [SHOW_PAYMENT_MENU]
+            buildConfigField "boolean", "SHOW_BULK_CN_MENU", [SHOW_BULK_CN_MENU]
+            buildConfigField "String", "APP_DIR", [APP_DIR_NAME]
+            buildConfigField "String", "API_VERSION", [API_VERSION]
+            buildConfigField "String", "RAR_PASSWORD", [RAR_PASSWORD]
+            resValue "string", "app_name_policies", [APP_NAME]
+        }
+    }
+    sourceSets {
+        example.java.srcDir [JAVA_DIR]
+        example.res.srcDir [RES_DIR]
+    }
+}


### PR DESCRIPTION
Changes:
- Added loadign `custom-flavours.gradle` to add additional product flavours without changing `build,gradle` file
- Added `custom-flavours.gradle` to `.gitignore`
- Added `custom-flavours.gradle.dist` as an example of custom flavour

[https://openimis.atlassian.net/browse/OP-440](https://openimis.atlassian.net/browse/OP-440)