### PR TITLE
Server error when sending data with accents

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ToRestApi.java
+++ b/app/src/main/java/org/openimis/imispolicies/ToRestApi.java
@@ -97,7 +97,7 @@ public class ToRestApi {
 
         try {
             if (object != null) {
-                StringEntity postingString = new StringEntity(object.toString());
+                StringEntity postingString = new StringEntity(object.toString(), "UTF8");
                 httpPost.setEntity(postingString);
             }
             HttpResponse response = httpClient.execute(httpPost);


### PR DESCRIPTION
Enter patient names with accents results in a failure to upload enrollments.
