### PR TITLE
Add an `IS_PAYMENT_ENABLED` feature flag.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ android {
         buildConfigField "String", "RAR_PASSWORD", '")(#$1HsD"'
         buildConfigField "String", "API_VERSION", '"3"'
         buildConfigField "String", "DEFAULT_LANGUAGE_CODE", '"en"'
+        buildConfigField "boolean", "IS_PAYMENT_ENABLED", 'false'
         resValue "string", "app_name_policies", "Policies"
         resValue "string", "ReleaseDateValue", getDate()
     }


### PR DESCRIPTION
Since the mobile payment API was very specific to Tanzania, we did leave the login on both systems to still be able to operate those features. This PR introduces a feature flag to remove the login to the old REST API if the payment features are not required, which should be almost everyone now. Implemented by Benjamin, tested to allow login by Eric. Further testing will be performed to make sure that it is working in a complete flow except the country specific aspects.

The `Login` use case authenticates with the old REST API in order to stay compatible with some non-migrated calls.
Yet, it seems those calls are not broadly used and should only be enabled for specific flavors.
Therefore, we introduce a build-time feature flag to only log in with the REST API if needed.
The feature flag also impacts the `LoginRepository`, which is instructed to check the validity of the REST token only if the feature flag is enabled.

Attention needs to be drawn to the fact that this feature flag does not disable the REST calls but only the login part. If some more in-depth modifications need to be made, a proper analysis should be made first.

MGOM2-12