### PR TITLE
keep screen on

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -48,6 +48,7 @@ import android.util.Base64;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.WindowManager;
 import android.webkit.JavascriptInterface;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -2541,6 +2542,9 @@ public class ClientAndroidInterface {
     @SuppressWarnings("unused")
     public void uploadEnrolment() throws Exception {
         final ProgressDialog finalPd = ProgressDialog.show(activity, activity.getResources().getString(R.string.Sync), activity.getResources().getString(R.string.SyncProcessing));
+        activity.runOnUiThread(() -> {
+            activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        });
         try {
             new Thread(() -> {
                 try {

--- a/app/src/main/java/org/openimis/imispolicies/MainActivity.java
+++ b/app/src/main/java/org/openimis/imispolicies/MainActivity.java
@@ -44,6 +44,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -500,6 +501,7 @@ public class MainActivity extends AppCompatActivity
                                     if (!global.isNetworkAvailable()) {
                                         PickMasterDataFileDialog();
                                     } else {
+                                        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                                         new MasterDataAsync(this).execute();
                                     }
                                     //ca.downloadMasterData();
@@ -526,6 +528,7 @@ public class MainActivity extends AppCompatActivity
                             if (!global.isNetworkAvailable()) {
                                 PickMasterDataFileDialog();
                             } else {
+                                getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                                 new MasterDataAsync(this).execute();
                             }
                         })

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     tools:openDrawer="start"
+    android:keepScreenOn="false"
 
     >
 


### PR DESCRIPTION
Allow app rights to keep screen on. 

During synchronisation process (or all other slow process) mobile app were shutting down and block finalization of processes