### PR TITLE
Improve enquiring process #OP-2615

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ fastlane/readme.md
 
 app/release/output.json
 .DS_Store
+*.DS_Store
+./.DS_Store
+./.git/.DS_Store
 
 # Custom product flavours
 

--- a/app/src/main/graphql/org.openimis.imispolicies/GetInsureeInquire.graphql
+++ b/app/src/main/graphql/org.openimis.imispolicies/GetInsureeInquire.graphql
@@ -53,6 +53,7 @@ query GetInsureeInquire($chfId: String) {
                                 expiryDate
                                 status
                                 value
+                                validityTo
                             }
                         }
                     }

--- a/app/src/main/java/org/openimis/imispolicies/Enquire.java
+++ b/app/src/main/java/org/openimis/imispolicies/Enquire.java
@@ -269,96 +269,98 @@ public class Enquire extends ImisActivity {
                 }
 
                 for (Policy policy : insuree.getPolicies()) {
-                    HashMap<String, String> policyMap = new HashMap<>();
+                    if(policy.getValidityTo() == null) {
+                        HashMap<String, String> policyMap = new HashMap<>();
 
-                    double iDedType = policy.getDeductibleType() == null ? 0 : policy.getDeductibleType();
+                        double iDedType = policy.getDeductibleType() == null ? 0 : policy.getDeductibleType();
 
-                    String Ded = "", Ded1 = "", Ded2 = "";
-                    String Ceiling = "", Ceiling1 = "", Ceiling2 = "";
+                        String Ded = "", Ded1 = "", Ded2 = "";
+                        String Ceiling = "", Ceiling1 = "", Ceiling2 = "";
 
-                    //Get the type
-                    if (iDedType == 1 | iDedType == 2 | iDedType == 3) {
-                        if (policy.getDeductibleIp() != null)
-                            Ded1 = String.valueOf(policy.getDeductibleIp());
-                        if (policy.getCeilingIp() != null)
-                            Ceiling1 = String.valueOf(policy.getCeilingIp());
+                        //Get the type
+                        if (iDedType == 1 | iDedType == 2 | iDedType == 3) {
+                            if (policy.getDeductibleIp() != null)
+                                Ded1 = String.valueOf(policy.getDeductibleIp());
+                            if (policy.getCeilingIp() != null)
+                                Ceiling1 = String.valueOf(policy.getCeilingIp());
 
-                        if (!Ded1.equals("")) Ded = "Deduction: " + Ded1;
-                        if (!Ceiling1.equals("")) Ceiling = "Ceiling: " + Ceiling1;
+                            if (!Ded1.equals("")) Ded = "Deduction: " + Ded1;
+                            if (!Ceiling1.equals("")) Ceiling = "Ceiling: " + Ceiling1;
 
-                    } else if (iDedType == 1.1 | iDedType == 2.1 | iDedType == 3.1) {
+                        } else if (iDedType == 1.1 | iDedType == 2.1 | iDedType == 3.1) {
 
-                        if (policy.getDeductibleIp() != null)
-                            Ded1 = " IP:" + policy.getDeductibleIp();
-                        if (policy.getDeductibleOp() != null)
-                            Ded2 = " OP:" + policy.getDeductibleOp();
-                        if (policy.getCeilingIp() != null)
-                            Ceiling1 = " IP:" + policy.getCeilingIp();
-                        if (policy.getCeilingOp() != null)
-                            Ceiling2 = " OP:" + policy.getCeilingOp();
+                            if (policy.getDeductibleIp() != null)
+                                Ded1 = " IP:" + policy.getDeductibleIp();
+                            if (policy.getDeductibleOp() != null)
+                                Ded2 = " OP:" + policy.getDeductibleOp();
+                            if (policy.getCeilingIp() != null)
+                                Ceiling1 = " IP:" + policy.getCeilingIp();
+                            if (policy.getCeilingOp() != null)
+                                Ceiling2 = " OP:" + policy.getCeilingOp();
 
-                        if (!(Ded1 + Ded2).equals("")) Ded = "Deduction: " + Ded1 + Ded2;
-                        if (!(Ceiling1 + Ceiling2).equals(""))
-                            Ceiling = "Ceiling: " + Ceiling1 + Ceiling2;
+                            if (!(Ded1 + Ded2).equals("")) Ded = "Deduction: " + Ded1 + Ded2;
+                            if (!(Ceiling1 + Ceiling2).equals(""))
+                                Ceiling = "Ceiling: " + Ceiling1 + Ceiling2;
 
-                    }
-
-                    if (policy.getExpiryDate() == null) {
-                        policyMap.put("Heading", getResources().getString(R.string.EnquireNoPolicies));
-                    } else {
-                        String expiryDate = policy.getExpiryDate() != null ?
-                                DateUtils.toDateString(policy.getExpiryDate()) : null;
-                        String status = policy.getStatus().name();
-                        String heading1;
-                        if (expiryDate != null) {
-                            heading1 = expiryDate + " " + status;
-                        } else {
-                            heading1 = status;
                         }
-                        policyMap.put("Heading", policy.getCode());
-                        policyMap.put("Heading1", heading1);
-                        policyMap.put("SubItem1", policy.getName());
-                        policyMap.put("SubItem2", Ded);
-                        policyMap.put("SubItem3", Ceiling);
-                    }
 
-                    if (!ca.getSpecificControl("TotalAdmissionsLeft").equals("N")) {
-                        policyMap.put("SubItem4", buildEnquireValue(policy.getTotalAdmissionsLeft(), R.string.totalAdmissionsLeft));
-                    }
-                    if (!ca.getSpecificControl("TotalVisitsLeft").equals("N")) {
-                        policyMap.put("SubItem5", buildEnquireValue(policy.getTotalVisitsLeft(), R.string.totalVisitsLeft));
-                    }
-                    if (!ca.getSpecificControl("TotalConsultationsLeft").equals("N")) {
-                        policyMap.put("SubItem6", buildEnquireValue(policy.getTotalConsultationsLeft(), R.string.totalConsultationsLeft));
-                    }
-                    if (!ca.getSpecificControl("TotalSurgeriesLeft").equals("N")) {
-                        policyMap.put("SubItem7", buildEnquireValue(policy.getTotalSurgeriesLeft(), R.string.totalSurgeriesLeft));
-                    }
-                    if (!ca.getSpecificControl("TotalDelivieriesLeft").equals("N")) {
-                        policyMap.put("SubItem8", buildEnquireValue(policy.getTotalDeliveriesLeft(), R.string.totalDeliveriesLeft));
-                    }
-                    if (!ca.getSpecificControl("TotalAntenatalLeft").equals("N")) {
-                        policyMap.put("SubItem9", buildEnquireValue(policy.getTotalAntenatalLeft(), R.string.totalAntenatalLeft));
-                    }
-                    if (!ca.getSpecificControl("ConsultationAmountLeft").equals("N")) {
-                        policyMap.put("SubItem10", buildEnquireValue(policy.getConsultationAmountLeft(), R.string.consultationAmountLeft));
-                    }
-                    if (!ca.getSpecificControl("SurgeryAmountLeft").equals("N")) {
-                        policyMap.put("SubItem11", buildEnquireValue(policy.getSurgeryAmountLeft(), R.string.surgeryAmountLeft));
-                    }
-                    if (!ca.getSpecificControl("HospitalizationAmountLeft").equals("N")) {
-                        policyMap.put("SubItem12", buildEnquireValue(policy.getHospitalizationAmountLeft(), R.string.hospitalizationAmountLeft));
-                    }
-                    if (!ca.getSpecificControl("AntenatalAmountLeft").equals("N")) {
-                        policyMap.put("SubItem13", buildEnquireValue(policy.getAntenatalAmountLeft(), R.string.antenatalAmountLeft));
-                    }
-                    if (!ca.getSpecificControl("DeliveryAmountLeft").equals("N")) {
-                        policyMap.put("SubItem14", buildEnquireValue(policy.getDeliveryAmountLeft(), R.string.deliveryAmountLeft));
-                    }
+                        if (policy.getExpiryDate() == null) {
+                            policyMap.put("Heading", getResources().getString(R.string.EnquireNoPolicies));
+                        } else {
+                            String expiryDate = policy.getExpiryDate() != null ?
+                                    DateUtils.toDateString(policy.getExpiryDate()) : null;
+                            String status = policy.getStatus().name();
+                            String heading1;
+                            if (expiryDate != null) {
+                                heading1 = expiryDate + " " + status;
+                            } else {
+                                heading1 = status;
+                            }
+                            policyMap.put("Heading", policy.getCode());
+                            policyMap.put("Heading1", heading1);
+                            policyMap.put("SubItem1", policy.getName());
+                            policyMap.put("SubItem2", Ded);
+                            policyMap.put("SubItem3", Ceiling);
+                        }
 
-                    PolicyList.add(policyMap);
-                    etCHFID.setText("");
-                    //break;
+                        if (!ca.getSpecificControl("TotalAdmissionsLeft").equals("N")) {
+                            policyMap.put("SubItem4", buildEnquireValue(policy.getTotalAdmissionsLeft(), R.string.totalAdmissionsLeft));
+                        }
+                        if (!ca.getSpecificControl("TotalVisitsLeft").equals("N")) {
+                            policyMap.put("SubItem5", buildEnquireValue(policy.getTotalVisitsLeft(), R.string.totalVisitsLeft));
+                        }
+                        if (!ca.getSpecificControl("TotalConsultationsLeft").equals("N")) {
+                            policyMap.put("SubItem6", buildEnquireValue(policy.getTotalConsultationsLeft(), R.string.totalConsultationsLeft));
+                        }
+                        if (!ca.getSpecificControl("TotalSurgeriesLeft").equals("N")) {
+                            policyMap.put("SubItem7", buildEnquireValue(policy.getTotalSurgeriesLeft(), R.string.totalSurgeriesLeft));
+                        }
+                        if (!ca.getSpecificControl("TotalDelivieriesLeft").equals("N")) {
+                            policyMap.put("SubItem8", buildEnquireValue(policy.getTotalDeliveriesLeft(), R.string.totalDeliveriesLeft));
+                        }
+                        if (!ca.getSpecificControl("TotalAntenatalLeft").equals("N")) {
+                            policyMap.put("SubItem9", buildEnquireValue(policy.getTotalAntenatalLeft(), R.string.totalAntenatalLeft));
+                        }
+                        if (!ca.getSpecificControl("ConsultationAmountLeft").equals("N")) {
+                            policyMap.put("SubItem10", buildEnquireValue(policy.getConsultationAmountLeft(), R.string.consultationAmountLeft));
+                        }
+                        if (!ca.getSpecificControl("SurgeryAmountLeft").equals("N")) {
+                            policyMap.put("SubItem11", buildEnquireValue(policy.getSurgeryAmountLeft(), R.string.surgeryAmountLeft));
+                        }
+                        if (!ca.getSpecificControl("HospitalizationAmountLeft").equals("N")) {
+                            policyMap.put("SubItem12", buildEnquireValue(policy.getHospitalizationAmountLeft(), R.string.hospitalizationAmountLeft));
+                        }
+                        if (!ca.getSpecificControl("AntenatalAmountLeft").equals("N")) {
+                            policyMap.put("SubItem13", buildEnquireValue(policy.getAntenatalAmountLeft(), R.string.antenatalAmountLeft));
+                        }
+                        if (!ca.getSpecificControl("DeliveryAmountLeft").equals("N")) {
+                            policyMap.put("SubItem14", buildEnquireValue(policy.getDeliveryAmountLeft(), R.string.deliveryAmountLeft));
+                        }
+
+                        PolicyList.add(policyMap);
+                        etCHFID.setText("");
+                        //break;
+                    }
                 }
             }
             ListAdapter adapter = new SimpleAdapter(Enquire.this,
@@ -449,7 +451,8 @@ public class Enquire extends ImisActivity {
                         /* totalConsultationsLeft = */ null,
                         /* totalDeliveriesLeft = */ null,
                         /* totalSurgeriesLeft = */ null,
-                        /* totalVisitsLeft = */ null
+                        /* totalVisitsLeft = */ null,
+                        /* validityTo = */ null
                 ));
             }
             c.close();

--- a/app/src/main/java/org/openimis/imispolicies/domain/entity/Policy.java
+++ b/app/src/main/java/org/openimis/imispolicies/domain/entity/Policy.java
@@ -53,6 +53,8 @@ public class Policy implements Parcelable {
     private final Integer totalSurgeriesLeft;
     @Nullable
     private final Integer totalVisitsLeft;
+    @Nullable
+    private final Date validityTo;
 
     public Policy(
             @NonNull String code,
@@ -75,7 +77,8 @@ public class Policy implements Parcelable {
             @Nullable Integer totalConsultationsLeft,
             @Nullable Integer totalDeliveriesLeft,
             @Nullable Integer totalSurgeriesLeft,
-            @Nullable Integer totalVisitsLeft
+            @Nullable Integer totalVisitsLeft,
+            @Nullable Date validityTo
     ) {
         this.code = code;
         this.name = name;
@@ -98,6 +101,7 @@ public class Policy implements Parcelable {
         this.totalDeliveriesLeft = totalDeliveriesLeft;
         this.totalSurgeriesLeft = totalSurgeriesLeft;
         this.totalVisitsLeft = totalVisitsLeft;
+        this.validityTo = validityTo;
     }
 
     protected Policy(Parcel in) {
@@ -193,6 +197,11 @@ public class Policy implements Parcelable {
             totalVisitsLeft = null;
         } else {
             totalVisitsLeft = in.readInt();
+        }
+        if (in.readByte() == 0) {
+            validityTo = null;
+        } else {
+            validityTo = new Date(in.readLong());
         }
     }
 
@@ -309,6 +318,12 @@ public class Policy implements Parcelable {
             dest.writeByte((byte) 1);
             dest.writeInt(totalVisitsLeft);
         }
+        if (validityTo == null) {
+            dest.writeByte((byte) 0);
+        } else {
+            dest.writeByte((byte) 1);
+            dest.writeLong(validityTo.getTime());
+        }
     }
 
     @Override
@@ -420,6 +435,9 @@ public class Policy implements Parcelable {
     public Integer getTotalVisitsLeft() {
         return totalVisitsLeft;
     }
+
+    @Nullable
+    public Date getValidityTo() { return validityTo; }
 
     public enum Status {
         IDLE, ACTIVE, SUSPENDED, EXPIRED, READY

--- a/app/src/main/java/org/openimis/imispolicies/usecase/FetchInsureeInquire.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/FetchInsureeInquire.java
@@ -90,7 +90,8 @@ public class FetchInsureeInquire {
                 /* totalConsultationsLeft = */ product.maxNoConsultation(),
                 /* totalDeliveriesLeft = */ product.maxNoDelivery(),
                 /* totalSurgeriesLeft = */ product.maxNoSurgery(),
-                /* totalVisitsLeft = */ product.maxNoVisits()
+                /* totalVisitsLeft = */ product.maxNoVisits(),
+                /* validityTo = */ policy.validityTo()
         );
     }
 

--- a/app/src/main/res/layout/policylist.xml
+++ b/app/src/main/res/layout/policylist.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-	android:layout_height="wrap_content"
+	android:layout_height="100dp"
 	android:orientation="vertical"
 	android:paddingBottom="5dp">
 


### PR DESCRIPTION
On the release instance, the result of enquiring process on the mobile app is different to the family policies on web
for example for family 172000001 shows one policy on the web, but when performing an enquiry for the same family on the mobile app, the result displays 7 policies.

To resolve this issue, I added a check on the validityTo field of the retrieved policies. Only the policies with validityTo = null will be displayed