### PR TITLE
fix officerCode is null on login - OP-2791

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
@@ -53,7 +53,10 @@ public class Login {
 
     @WorkerThread
     public void execute(@NonNull String username, @NonNull String password) throws Exception {
-        String officerCode = Global.getGlobal().getOfficerCode();
+        String officerCode = (Global.getGlobal().getOfficerCode() != null)
+                ? Global.getGlobal().getOfficerCode()
+                : username;
+
         if (officerCode == null) {
             throw new IllegalStateException("OfficerCode should not be null on login");
         }

--- a/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
@@ -53,10 +53,10 @@ public class Login {
 
     @WorkerThread
     public void execute(@NonNull String username, @NonNull String password) throws Exception {
-        String officerCode = (Global.getGlobal().getOfficerCode() != null)
-                ? Global.getGlobal().getOfficerCode()
-                : username;
-
+        if (Global.getGlobal().getOfficerCode() == null) {
+            Global.getGlobal().setOfficerCode(username);
+        }
+        String officerCode = Global.getGlobal().getOfficerCode();
         if (officerCode == null) {
             throw new IllegalStateException("OfficerCode should not be null on login");
         }


### PR DESCRIPTION
After the master data download fails with a 403 Forbidden error, we are redirected to the login page. When we try to log in, the connection fails, returning the error message "officerCode should not be null on login". This officerCode is the same as the username, so we added a control to set the username as the default value for the Global.OfficerCode property in cases where the latter is null at login.


<img width="1807" height="882" alt="Capture d’écran du 2025-11-12 07-26-20" src="https://github.com/user-attachments/assets/8230afb3-3a8a-46eb-882e-c765a5c43986" />
<img width="1789" height="281" alt="Capture d’écran du 2025-11-12 07-33-49" src="https://github.com/user-attachments/assets/6e43d267-7a8f-41cf-affb-2debd8def3c2" />
<img width="1763" height="792" alt="Capture d’écran du 2025-11-12 07-34-06" src="https://github.com/user-attachments/assets/cdbc39b4-5cb2-47ae-bb6d-bfdb3288b2b2" />
