### PR TITLE
fix error when downloading family data

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -4852,9 +4852,12 @@ public class ClientAndroidInterface {
         policyObject.put("PolicyId",policy.getId());
         policyObject.put("FamilyId",policy.getFamilyId());
         policyObject.put("EnrollDate",policy.getEnrollDate());
-        policyObject.put("StartDate",DateUtils.toDateString(Objects.requireNonNull(policy.getStartDate())));
-        policyObject.put("EffectiveDate",  DateUtils.toDateString(Objects.requireNonNull(policy.getEffectiveDate())));
-        policyObject.put("ExpiryDate", DateUtils.toDateString(Objects.requireNonNull(policy.getExpiryDate())));
+        policyObject.put("StartDate",
+            policy.getStartDate() != null ? DateUtils.toDateString(policy.getStartDate()) : JSONObject.NULL);
+        policyObject.put("EffectiveDate",
+            policy.getEffectiveDate() != null ? DateUtils.toDateString(policy.getEffectiveDate()) : JSONObject.NULL);
+        policyObject.put("ExpiryDate",
+            policy.getExpiryDate() != null ? DateUtils.toDateString(policy.getExpiryDate()) : JSONObject.NULL);
         policyObject.put("PolicyStatus",policy.getStatus());
         policyObject.put("PolicyValue",policy.getValue());
         policyObject.put("ProdId",policy.getProductId());

--- a/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
@@ -53,7 +53,10 @@ public class Login {
 
     @WorkerThread
     public void execute(@NonNull String username, @NonNull String password) throws Exception {
-        String officerCode = Global.getGlobal().getOfficerCode();
+        String officerCode = (Global.getGlobal().getOfficerCode() != null)
+                ? Global.getGlobal().getOfficerCode()
+                : username;
+
         if (officerCode == null) {
             throw new IllegalStateException("OfficerCode should not be null on login");
         }

--- a/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/Login.java
@@ -53,10 +53,10 @@ public class Login {
 
     @WorkerThread
     public void execute(@NonNull String username, @NonNull String password) throws Exception {
-        String officerCode = (Global.getGlobal().getOfficerCode() != null)
-                ? Global.getGlobal().getOfficerCode()
-                : username;
-
+        if (Global.getGlobal().getOfficerCode() == null) {
+            Global.getGlobal().setOfficerCode(username);
+        }
+        String officerCode = Global.getGlobal().getOfficerCode();
         if (officerCode == null) {
             throw new IllegalStateException("OfficerCode should not be null on login");
         }


### PR DESCRIPTION
When downloading data for a family that has policies from the server, an error message appears, and although the family is downloaded, its policies are not retrieved, even though they are correctly returned by the server. This is due to an error with null dates in the policy data. To fix this, we have implemented a more robust handling of "null" date cases in the data parsing.

<img width="516" height="1027" alt="Capture d’écran du 2025-11-18 19-23-02" src="https://github.com/user-attachments/assets/604454e6-6ba1-4e9c-ada0-918934babdbc" />
