### PR TITLE
add OutOfMemory clause

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -3967,6 +3967,10 @@ public class ClientAndroidInterface {
                 throw (UserNotAuthenticatedException) e;
             }
             throw new UserException("Error while downloading the master data", e);
+        } catch (OutOfMemoryError e){
+            Sentry.captureException(e);
+            activity.runOnUiThread(() ->
+                    AndroidUtils.showToast(activity,e.getMessage()));
         }
     }
 


### PR DESCRIPTION

# Description

We have implemented a fix for the Cameroon deployment to handle large master data downloads (5MB+). This update prevents application crashes caused by memory constraints and ensures that errors are gracefully communicated to the user through toast alerts

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Demo
<img width="1346" height="331" alt="Screenshot 2026-04-01 at 2 42 25 PM" src="https://github.com/user-attachments/assets/d0e24f90-18e7-457a-951d-54afc9d0a8dd" />
![Screenshot_20260401-144213](https://github.com/user-attachments/assets/b3efb40e-3364-42ad-9eb5-77fcd25a9c0d)


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
