### PR TITLE
Fix: Django session handling

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/Global.java
+++ b/app/src/main/java/org/openimis/imispolicies/Global.java
@@ -46,6 +46,7 @@ import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.openimis.imispolicies.network.util.PersistentCookieJar;
 import org.openimis.imispolicies.repository.LoginRepository;
 import org.openimis.imispolicies.tools.Log;
 import org.openimis.imispolicies.util.StreamUtils;
@@ -99,6 +100,7 @@ public class Global extends Application {
     private String AppDirectory;
     private Map<String,
             String> SubDirectories;
+    private PersistentCookieJar cookieJar;
     private volatile LoginRepository loginRepository;
     public static Global getGlobal() {
         return GlobalContext;
@@ -116,6 +118,13 @@ public class Global extends Application {
         initSharedPrefsInts();
     }
 
+    public void setCookieJar(PersistentCookieJar jar) {
+        this.cookieJar = jar;
+    }
+
+    public PersistentCookieJar getCookieJar() {
+        return cookieJar;
+    }
     protected boolean isRunningTest() {
         try {
             Class.forName("org.robolectric.RobolectricTestRunner");

--- a/app/src/main/java/org/openimis/imispolicies/network/okhttp/AuthorizationInterceptor.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/okhttp/AuthorizationInterceptor.java
@@ -3,6 +3,7 @@ package org.openimis.imispolicies.network.okhttp;
 import androidx.annotation.NonNull;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openimis.imispolicies.Global;
 import org.openimis.imispolicies.MainActivity;
 import org.openimis.imispolicies.repository.LoginRepository;
 
@@ -12,6 +13,7 @@ import java.net.HttpURLConnection;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 public class AuthorizationInterceptor implements Interceptor {
     private static final String USER_AGENT = "mobile_app";
@@ -38,8 +40,14 @@ public class AuthorizationInterceptor implements Interceptor {
             builder.addHeader("X-Csrftoken", csrfToken);
         }
         Response response = chain.proceed(builder.build());
-        if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+        ResponseBody body = response.peekBody(Long.MAX_VALUE);
+        String bodyString = body.string();
+        if (bodyString.contains("'csrftoken'") || response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
             repository.saveFhirToken(null, null, null);
+            repository.saveCsrfToken(null);
+            if (Global.getGlobal().getCookieJar() != null) {
+                Global.getGlobal().getCookieJar().clear();
+            }
             MainActivity.SetLoggedIn();
         }
         return response;

--- a/app/src/main/java/org/openimis/imispolicies/network/util/OkHttpUtils.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/util/OkHttpUtils.java
@@ -1,6 +1,11 @@
 package org.openimis.imispolicies.network.util;
 
+import static android.content.Context.MODE_PRIVATE;
+
+import static org.openimis.imispolicies.Global.PREF_NAME;
+
 import android.annotation.SuppressLint;
+import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 
@@ -30,6 +35,10 @@ public class OkHttpUtils {
             synchronized (OkHttpUtils.class) {
                 if (client == null) {
                     OkHttpClient.Builder builder = new OkHttpClient.Builder();
+                    PersistentCookieJar cookieJar =
+                            new PersistentCookieJar(Global.getGlobal().getSharedPreferences(PREF_NAME, MODE_PRIVATE));
+                    Global.getGlobal().setCookieJar(cookieJar);
+                    builder.cookieJar(cookieJar);
                     HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
                     interceptor.setLevel(BuildConfig.DEBUG ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.BASIC);
                     builder.addInterceptor(interceptor);

--- a/app/src/main/java/org/openimis/imispolicies/network/util/PersistentCookieJar.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/util/PersistentCookieJar.java
@@ -1,0 +1,63 @@
+package org.openimis.imispolicies.network.util;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PersistentCookieJar implements CookieJar {
+
+    private final SharedPreferences prefs;
+
+    public PersistentCookieJar(SharedPreferences prefs) {
+        this.prefs = prefs;
+    }
+
+    @Override
+    public void saveFromResponse(@NonNull HttpUrl url, List<Cookie> cookies) {
+
+        for (Cookie cookie : cookies) {
+            if ("openimis_session".equals(cookie.name())) {
+
+                prefs.edit()
+                        .putString("session_value", cookie.value())
+                        .putLong("session_expiry", cookie.expiresAt())
+                        .apply();
+            }
+        }
+    }
+
+    @NonNull
+    @Override
+    public List<Cookie> loadForRequest(HttpUrl url) {
+
+        String value = prefs.getString("session_value", null);
+        long expiry = prefs.getLong("session_expiry", -1);
+
+        if (value == null || expiry == -1) {
+            return new ArrayList<>();
+        }
+
+        Cookie cookie = new Cookie.Builder()
+                .name("openimis_session")
+                .value(value)
+                .domain(url.host())
+                .path("/")
+                .expiresAt(expiry)
+                .build();
+
+        List<Cookie> cookies = new ArrayList<>();
+        cookies.add(cookie);
+        return cookies;
+    }
+
+    public void clear() {
+        prefs.edit().clear().apply();
+    }
+}

--- a/app/src/main/java/org/openimis/imispolicies/repository/LoginRepository.java
+++ b/app/src/main/java/org/openimis/imispolicies/repository/LoginRepository.java
@@ -1,5 +1,8 @@
 package org.openimis.imispolicies.repository;
 
+import static android.content.Context.MODE_PRIVATE;
+import static org.openimis.imispolicies.Global.PREF_NAME;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
@@ -13,6 +16,7 @@ import org.json.JSONObject;
 import org.openimis.imispolicies.BuildConfig;
 import org.openimis.imispolicies.Global;
 import org.openimis.imispolicies.Token;
+import org.openimis.imispolicies.network.util.PersistentCookieJar;
 import org.openimis.imispolicies.tools.Log;
 
 import java.util.Date;
@@ -37,7 +41,7 @@ public class LoginRepository {
 
     public LoginRepository(@NonNull Context context, boolean isPaymentEnabled) {
         this.isPaymentEnabled = isPaymentEnabled;
-        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        prefs = context.getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         if (!prefs.getBoolean(HAS_MIGRATED, false)) {
             migrateOldTokens();
         }
@@ -167,7 +171,21 @@ public class LoginRepository {
         if (isPaymentEnabled && getRestToken() == null) {
             return false;
         }
-        return getFhirToken() != null;
+
+        PersistentCookieJar cookieJar = Global.getGlobal().getCookieJar();
+        long expiry = Global.getGlobal().getSharedPreferences(PREF_NAME, MODE_PRIVATE)
+                .getLong("session_expiry", 0);
+
+        boolean isLoggedIn = getFhirToken() != null
+                && expiry > System.currentTimeMillis();
+
+        if (!isLoggedIn) {
+            if (cookieJar != null) {
+                cookieJar.clear();
+            }
+        }
+
+        return isLoggedIn;
     }
 
     public void logout() {


### PR DESCRIPTION
# Description

- Django mobile-side handling of the openimis_session cookie ( local persistence, invalidation and cleansing ) and injection of the cookie accompanied by X-CSRFToken header into HTTP requests using a CookieJar to address the session instability or invalidity issue that causes the `errors[0].message = "csrftoken"` server response in mobile requests.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="468" height="1004" alt="csrf_error_policies_phone" src="https://github.com/user-attachments/assets/7ff145b6-0b90-4d73-b1f0-6e7039179cfb" />
<img width="1730" height="855" alt="csrftoken_error_policies" src="https://github.com/user-attachments/assets/b092ad12-6f46-4bee-8e94-91f0265ee6b4" />
<img width="1476" height="736" alt="fix_csfttoken_policies" src="https://github.com/user-attachments/assets/07ff19c4-bcb5-4e41-871e-b6e3d228f4fd" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
