### PR TITLE
Fix: Manual build fails OP-3009

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,5 +1,8 @@
 name: manualbuild
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,4 +483,5 @@
     <string name="pay_type_cash">Cash</string>
     <string name="pay_type_mobile_phone">Mobile Phone</string>
     <string name="pay_type_bank_transfer">Bank Transfer</string>
+    <string name="Close">Close</string>
 </resources>


### PR DESCRIPTION
# Description

Fix: Manual build fails due to not found xml string ressources  and insufficient permissions to create a release

# Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference : https://openimis.atlassian.net/browse/OP-3009

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
