### PR TITLE
fix print user policy renewals

### DIFF
--- a/app/src/main/graphql/org.openimis.imispolicies/GetPolicyRenewals.graphql
+++ b/app/src/main/graphql/org.openimis.imispolicies/GetPolicyRenewals.graphql
@@ -1,0 +1,32 @@
+query GetPolicyRenewals($officerCode: String) {
+    policies(stage: "R", officer_Code: $officerCode,  orderBy: ["-enrollDate"]){
+        edges {
+            node {
+                id
+                uuid
+                startDate
+                product {
+                    id
+                    code
+                    name
+                }
+                officer {
+                    id
+                    code
+                }
+                family {
+                    headInsuree {
+                        id
+                        chfId
+                        lastName
+                        otherNames
+                        phone
+                        currentVillage {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -2273,8 +2273,8 @@ public class ClientAndroidInterface {
     public String OfflineRenewals(String OfficerCode) {
         @Language("SQL")
         String Query = "SELECT RenewalId, PolicyId, OfficerId, OfficerCode, CHFID, LastName, OtherNames, ProductCode, ProductName, VillageName, RenewalPromptDate, IMEI, Phone,LocationId,PolicyValue, EnrollDate, RenewalUUID " +
-                " FROM tblRenewals WHERE LOWER(OfficerCode)=? AND isDone = ? ";
-        String[] arg = {OfficerCode.toLowerCase(), "N"};
+                " FROM tblRenewals WHERE isDone = ? ";
+        String[] arg = {"N"};
         JSONArray Renews = sqlHandler.getResult(Query, arg);
         return Renews.toString();
     }

--- a/app/src/main/java/org/openimis/imispolicies/RenewList.java
+++ b/app/src/main/java/org/openimis/imispolicies/RenewList.java
@@ -57,16 +57,20 @@ import org.openimis.imispolicies.domain.entity.PolicyRenewal;
 import org.openimis.imispolicies.network.exception.HttpException;
 import org.openimis.imispolicies.tools.Log;
 import org.openimis.imispolicies.usecase.FetchPolicyRenewals;
+import org.openimis.imispolicies.util.DateUtils;
 import org.openimis.imispolicies.util.FileUtils;
 import org.openimis.imispolicies.util.UriUtils;
 
 import java.io.File;
 import java.net.HttpURLConnection;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class RenewList extends AppCompatActivity {
@@ -280,6 +284,7 @@ public class RenewList extends AppCompatActivity {
 
         ClientAndroidInterface ca = new ClientAndroidInterface(this);
         String result = ca.OfflineRenewals(OfficerCode);
+        Log.e("policy renewals", result);
         JSONObject object;
 
         try {
@@ -312,13 +317,16 @@ public class RenewList extends AppCompatActivity {
             for (int i = 0; i < jsonArray.length(); i++) {
 
                 object = jsonArray.getJSONObject(i);
+                SimpleDateFormat inputFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
+                SimpleDateFormat outputFormat = new SimpleDateFormat("dd-MM-yyyy", Locale.ENGLISH);
+                Date promptDate = inputFormat.parse(object.getString("RenewalPromptDate"));
                 HashMap<String, String> renewal = new HashMap<>();
                 renewal.put("RenewalId", object.getString("RenewalId"));
                 renewal.put("CHFID", object.getString("CHFID"));
                 renewal.put("FullName", object.getString("LastName") + " " + object.getString("OtherNames"));
                 renewal.put("Product", object.getString("ProductCode") + " : " + object.getString("ProductName"));
                 renewal.put("VillageName", object.getString("VillageName"));
-                renewal.put("RenewalPromptDate", object.getString("RenewalPromptDate"));
+                renewal.put("RenewalPromptDate", format.format(promptDate));
                 renewal.put("PolicyId", object.getString("PolicyId"));
                 renewal.put("ProductCode", object.getString("ProductCode"));
                 renewal.put("LocationId", object.getString("LocationId"));
@@ -337,6 +345,8 @@ public class RenewList extends AppCompatActivity {
 
         } catch (JSONException e) {
             e.printStackTrace();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
         }
 
     }
@@ -347,7 +357,8 @@ public class RenewList extends AppCompatActivity {
                 new Thread(() -> {
 
                     try {
-                        List<PolicyRenewal> renewals = new FetchPolicyRenewals().execute();
+                        List<PolicyRenewal> renewals = new FetchPolicyRenewals().execute(OfficerCode);
+                        Log.e("renewals", toJson(renewals).toString());
                         ca.InsertRenewalsFromApi(toJson(renewals));
                         runOnUiThread(this::fillRenewals);
                     } catch (Exception e) {

--- a/app/src/main/java/org/openimis/imispolicies/network/request/GetPolicyRenewalsGraphQLRequest.java
+++ b/app/src/main/java/org/openimis/imispolicies/network/request/GetPolicyRenewalsGraphQLRequest.java
@@ -3,8 +3,10 @@ package org.openimis.imispolicies.network.request;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.Response;
 
+import org.openimis.imispolicies.GetPolicyRenewalsQuery;
 import org.openimis.imispolicies.GetRenewalsQuery;
 import org.openimis.imispolicies.network.exception.HttpException;
 
@@ -16,12 +18,12 @@ public class GetPolicyRenewalsGraphQLRequest extends BaseGraphQLRequest {
 
     @WorkerThread
     @NonNull
-    public List<GetRenewalsQuery.Edge> get() throws Exception {
-        Response<GetRenewalsQuery.Data> response = makeSynchronous(new GetRenewalsQuery());
-        GetRenewalsQuery.Data data = response.getData();
-        if (data == null || data.policyRenewals() == null) {
+    public List<GetPolicyRenewalsQuery.Edge> get(String officerCode) throws Exception {
+        Response<GetPolicyRenewalsQuery.Data> response = makeSynchronous(new GetPolicyRenewalsQuery(Input.fromNullable(officerCode)));
+        GetPolicyRenewalsQuery.Data data = response.getData();
+        if (data == null || data.policies() == null) {
             throw new HttpException(HttpURLConnection.HTTP_NOT_FOUND, "No renewals found", null, null);
         }
-        return Objects.requireNonNull(data.policyRenewals()).edges();
+        return Objects.requireNonNull(data.policies()).edges();
     }
 }

--- a/app/src/main/java/org/openimis/imispolicies/usecase/DeletePolicyRenewal.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/DeletePolicyRenewal.java
@@ -3,6 +3,7 @@ package org.openimis.imispolicies.usecase;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import org.openimis.imispolicies.Global;
 import org.openimis.imispolicies.ToRestApi;
 import org.openimis.imispolicies.domain.entity.PolicyRenewal;
 import org.openimis.imispolicies.network.exception.HttpException;
@@ -19,28 +20,32 @@ public class DeletePolicyRenewal {
     private final DeletePolicyRenewalGraphQLRequest deletePolicyRenewalGraphQLRequest;
     @NonNull
     private final CheckMutation checkMutation;
+    private final Global global;
 
     public DeletePolicyRenewal() {
         this(
                 new FetchPolicyRenewals(),
                 new DeletePolicyRenewalGraphQLRequest(),
-                new CheckMutation()
+                new CheckMutation(),
+                new Global()
         );
     }
 
     public DeletePolicyRenewal(
             @NonNull FetchPolicyRenewals fetchPolicyRenewals,
             @NonNull DeletePolicyRenewalGraphQLRequest deletePolicyRenewalGraphQLRequest,
-            @NonNull CheckMutation checkMutation
+            @NonNull CheckMutation checkMutation,
+            @NonNull Global global
     ) {
         this.fetchPolicyRenewals = fetchPolicyRenewals;
         this.deletePolicyRenewalGraphQLRequest = deletePolicyRenewalGraphQLRequest;
         this.checkMutation = checkMutation;
+        this.global = global;
     }
 
     @WorkerThread
     public int execute(int id) throws Exception {
-        List<PolicyRenewal> renewals = fetchPolicyRenewals.execute();
+        List<PolicyRenewal> renewals = fetchPolicyRenewals.execute(global.getOfficerCode());
         for (PolicyRenewal renewal : renewals) {
             if (renewal.getId() == id) {
                 return execute(renewal.getUuid());

--- a/app/src/main/java/org/openimis/imispolicies/usecase/FetchPolicyRenewals.java
+++ b/app/src/main/java/org/openimis/imispolicies/usecase/FetchPolicyRenewals.java
@@ -3,6 +3,7 @@ package org.openimis.imispolicies.usecase;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import org.openimis.imispolicies.GetPolicyRenewalsQuery;
 import org.openimis.imispolicies.GetRenewalsQuery;
 import org.openimis.imispolicies.domain.entity.PolicyRenewal;
 import org.openimis.imispolicies.domain.utils.IdUtils;
@@ -27,28 +28,28 @@ public class FetchPolicyRenewals {
 
     @NonNull
     @WorkerThread
-    public List<PolicyRenewal> execute() throws Exception {
-        List<GetRenewalsQuery.Edge> edges = getPolicyRenewalsGraphQLRequest.get();
+    public List<PolicyRenewal> execute(String officerCode) throws Exception {
+        List<GetPolicyRenewalsQuery.Edge> edges = getPolicyRenewalsGraphQLRequest.get(officerCode);
         return Mapper.map(edges, this::toRenewal);
     }
 
     @NonNull
-    private PolicyRenewal toRenewal(@NonNull GetRenewalsQuery.Edge edge) {
-        GetRenewalsQuery.Node node = Objects.requireNonNull(edge.node());
+    private PolicyRenewal toRenewal(@NonNull GetPolicyRenewalsQuery.Edge edge) {
+        GetPolicyRenewalsQuery.Node node = Objects.requireNonNull(edge.node());
         return new PolicyRenewal(
                 /* id = */ IdUtils.getIdFromGraphQLString(node.id()),
                 /* uuid = */ node.uuid(),
-                /* policyId = */ IdUtils.getIdFromGraphQLString(node.policy().id()),
-                /* officerId = */ IdUtils.getIdFromGraphQLString(node.policy().officer().id()),
-                /* officerCode = */ node.policy().officer().code(),
-                /* chfId = */ node.insuree().chfId(),
-                /* lastName = */ node.insuree().lastName(),
-                /* otherNames = */ node.insuree().otherNames(),
-                /* productCode = */ node.policy().product().code(),
-                /* productName = */ node.policy().product().name(),
-                /* villageName = */ node.insuree().currentVillage() != null ? node.insuree().currentVillage().name() : null,
-                /* renewalPromptDate = */ node.renewalPromptDate(),
-                /* phone = */ node.insuree().phone()
+                /* policyId = */ IdUtils.getIdFromGraphQLString(node.id()),
+                /* officerId = */ IdUtils.getIdFromGraphQLString(node.officer().id()),
+                /* officerCode = */ node.officer().code(),
+                /* chfId = */ node.family().headInsuree().chfId(),
+                /* lastName = */ node.family().headInsuree().lastName(),
+                /* otherNames = */ node.family().headInsuree().otherNames(),
+                /* productCode = */ node.product().code(),
+                /* productName = */ node.product().name(),
+                /* villageName = */ node.family().headInsuree().currentVillage() != null ? node.family().headInsuree().currentVillage().name() : null,
+                /* renewalPromptDate = */ node.startDate(),
+                /* phone = */ node.family().headInsuree().phone()
         );
     }
 }


### PR DESCRIPTION
# Description

In the mobile app, navigating to the "Policy Renewals" section returns no results. However, when filtering policies by the "Renewed" status on the web platform, the corresponding records are displayed correctly.
to fix that, I updated the GraphQL query to directly filter policies with a "Renewed" status based on the agent code, ensuring the correct records are returned in the mobile app's "Policy Renewals" section

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="360" height="800" alt="Screenshot_20260524_103244" src="https://github.com/user-attachments/assets/acc45a08-fb17-4f34-9296-53637759ac8e" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
