### PR TITLE
Align startup language with system locale in policies app

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/MainActivity.java
+++ b/app/src/main/java/org/openimis/imispolicies/MainActivity.java
@@ -234,6 +234,7 @@ public class MainActivity extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         global = (Global) getApplicationContext();
         super.onCreate(savedInstanceState);
+        new LanguageManager(this).restoreLanguage(false);
         try {
             instance = this;
             setContentView(R.layout.activity_main);
@@ -582,7 +583,7 @@ public class MainActivity extends AppCompatActivity
                             finish();
                         });
 
-         alertDialogBuilder.show();
+        alertDialogBuilder.show();
     }
 
     public String getMasterDataText2(String fileName, String password) {

--- a/app/src/main/java/org/openimis/imispolicies/tools/LanguageManager.java
+++ b/app/src/main/java/org/openimis/imispolicies/tools/LanguageManager.java
@@ -70,7 +70,7 @@ public class LanguageManager {
      * @param withRestart should the current context be restarted (if it's Activity).
      */
     public void restoreLanguage(boolean withRestart) {
-        String language = getStoredLanguage();
+        String language = resolveStartupLanguage();
         setLanguage(language, withRestart);
     }
 
@@ -182,6 +182,14 @@ public class LanguageManager {
             defaultLanguage = BuildConfig.DEFAULT_LANGUAGE_CODE;
         }
         return global.getStringKey(Global.PREF_LANGUAGE_KEY, defaultLanguage);
+    }
+
+    private String resolveStartupLanguage() {
+        String language = getCurrentLocale().getLanguage();
+        if ("fr".equalsIgnoreCase(language)) {
+            return "fr";
+        }
+        return "en";
     }
 
     /**

--- a/app/src/test/java/org/openimis/imispolicies/MainActivityTest.java
+++ b/app/src/test/java/org/openimis/imispolicies/MainActivityTest.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 @RunWith(RobolectricTestRunner.class)
 public class MainActivityTest {
 
-    // Tests de la branche feature-36746
     static class TestActivity extends MainActivity {}
     
     private void createActivity() {
@@ -56,7 +55,6 @@ public class MainActivityTest {
         assertEquals("en", Locale.getDefault().getLanguage());
     }
 
-    // Tests de la branche develop
     private MainActivity activity;
     private Global global;
 

--- a/app/src/test/java/org/openimis/imispolicies/MainActivityTest.java
+++ b/app/src/test/java/org/openimis/imispolicies/MainActivityTest.java
@@ -1,0 +1,43 @@
+package org.openimis.imispolicies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Locale;
+
+@RunWith(RobolectricTestRunner.class)
+public class MainActivityTest {
+
+    static class TestActivity extends MainActivity {}
+    private void createActivity() {
+        Robolectric.buildActivity(TestActivity.class)
+                .create()
+                .get();
+    }
+
+    @Test
+    @Config(qualifiers = "fr")
+    public void french_locale_restored() {
+        createActivity();
+        assertEquals("fr", Locale.getDefault().getLanguage());
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void english_locale_restored() {
+        createActivity();
+        assertEquals("en", Locale.getDefault().getLanguage());
+    }
+
+    @Test
+    @Config(qualifiers = "es")
+    public void unsupported_locale_defaults_en() {
+        createActivity();
+        assertEquals("en", Locale.getDefault().getLanguage());
+    }
+}


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

Align startup language with device locale in the mobile policies app. Defaults to system language, with fallback to English when the locale is neither French nor English, improving initial localization and user experience.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify
- [x] Enhancement

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
